### PR TITLE
REF update GoogleMaps dependency for iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "cordova-android",
     "cordova-ios"
   ],
-  "engines": [
-    {
-      "name": "cordova",
-      "version": ">=3.5.0"
+  "engines": {
+    "cordovaDependencies": {
+      "1.3.9": {
+        "cordova-ios": ">=3.0.0",
+        "cordova-android": ">=5.1.0"
+      }
     }
-  ],
+  },
   "author": "Masashi Katsumata, Hirbod Mirjavadi",
   "license": "Apache 2.0",
   "bugs": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -206,6 +206,6 @@
           </array>
         </config-file>
 
-        <dependency id="com.googlemaps.ios" url="https://github.com/helixhuang/cordova-plugin-googlemaps-sdk.git" commit="master" />
+        <framework src="GoogleMaps" type="podspec" spec="~> 1.13.0" />
     </platform>
 </plugin>


### PR DESCRIPTION
- Update GoogleMaps dependency for iOS
  - Now uses cocoapod instead of git repository
- Update package.json engine to be compatible with cordova > 6